### PR TITLE
plf: uart: hci&ahi: Adds retention handling

### DIFF
--- a/common/include/es0_power_manager.h
+++ b/common/include/es0_power_manager.h
@@ -37,4 +37,16 @@ int8_t take_es0_into_use(void);
  */
 int8_t stop_using_es0(void);
 
+/**
+ * @brief wakeup ES0 using uart
+ * 
+ * ES0 needs to be woken once per boot and should then remain active
+ * until ES1 is powered off.
+ * 
+ * This function can be called as many times during the boot.
+ * 
+ * @return 
+ */
+void wake_es0(const struct device *uart_dev);
+
 #endif /* __ES0_POWER_MANAGER_H__ */

--- a/common/src/es0_power_manager.c
+++ b/common/src/es0_power_manager.c
@@ -4,11 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+
 #include "es0_power_manager.h"
 #include "se_service.h"
 #include "alif_protocol_const.h"
 
 static volatile uint8_t es0_user_counter;
+static uint32_t wakeup_count;
+
 #define LL_BOOT_PARAMS_MAX_SIZE (512)
 
 #define LL_CLK_SEL_CTRL_REG_ADDR   0x1A60201C
@@ -215,3 +221,14 @@ int8_t stop_using_es0(void)
 
 	return 0;
 }
+
+void wake_es0(const struct device *uart_dev)
+{
+	if (wakeup_count == 0) {
+		uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_RTS, 0);
+		k_usleep(100);
+		uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_RTS, 1);
+		wakeup_count++;
+	}
+}
+

--- a/ieee802154/src/alif_ahi.c
+++ b/ieee802154/src/alif_ahi.c
@@ -84,6 +84,9 @@ int alif_ahi_msg_send(struct msg_buf *p_msg, const uint8_t *p_data, uint16_t dat
 		return -1;
 	}
 
+	/* Deassert&assert rts_n, falling edge triggers wake up the RF core */
+ 	wake_es0(uart_dev);
+
 	for (int i = 0; i < p_msg->msg_len; i++) {
 		uart_poll_out(uart_dev, p_msg->msg[i]);
 	}


### PR DESCRIPTION
* Link layer deep sleep requires that HCI and AHI UART lines set break condition.
* To keep track, if we want to resume, rely on a magic value which is retained over boot cycles.
* Wakeup the RF core - when ever we try to communicate with it - by toggling the RTS flow control line.