### PR TITLE
Hal fixs for SE service and ieee802.15.4 lib

### DIFF
--- a/common/src/es0_power_manager.c
+++ b/common/src/es0_power_manager.c
@@ -119,8 +119,20 @@ int8_t take_es0_into_use(void)
 	}
 
 	if (es0_user_counter == 0) {
-		/* Shuttdown is needed if riscv was already active */
-		se_service_shutdown_es0();
+		int err;
+		uint32_t version;
+
+		/* Synch at boot allways */
+		se_service_sync();
+		err = se_service_get_toc_version(&version);
+		if (err) {
+			return err;
+		}
+		/* v1.103. not need shuttdown */
+		if (version < 0x01670000) {
+			/* Shuttdown is needed if riscv was already active */
+			se_service_shutdown_es0();
+		}
 	}
 
 	static uint8_t ll_boot_params_buffer[LL_BOOT_PARAMS_MAX_SIZE];

--- a/ieee802154/include/ahi_msg_lib.h
+++ b/ieee802154/include/ahi_msg_lib.h
@@ -117,7 +117,7 @@ void alif_ahi_msg_pending_long_id_configure_1_1_0(struct msg_buf *p_msg, uint16_
 void alif_ahi_msg_ie_purge_all(struct msg_buf *p_msg, uint16_t ctx);
 void alif_ahi_msg_ie_header_gen(struct msg_buf *p_msg, uint16_t ctx, uint16_t short_id,
 				const uint8_t *p_extended_address,
-				const struct mac_ahi_header_ie *p_header_ie);
+				const struct alif_802154_header_ie *p_header_ie);
 
 void alif_ahi_msg_csl_period_set(struct msg_buf *p_msg, uint16_t ctx, uint16_t period);
 void alif_ahi_msg_csl_period_get(struct msg_buf *p_msg, uint16_t ctx);

--- a/ieee802154/include/alif_mac154_api.h
+++ b/ieee802154/include/alif_mac154_api.h
@@ -505,9 +505,10 @@ alif_mac154_csl_phase_get(struct alif_mac154_csl_phase *p_csl_phase_resp);
  *		ALIF_MAC154_STATUS_FAILED	Operation failed
  *		ALIF_MAC154_STATUS_COMM_FAILURE	Module not connected
  */
-enum alif_mac154_status_code
-alif_mac154_ack_header_ie_set(uint16_t short_address, const uint8_t *p_extended_address,
-			      bool delete_ie, const struct ieee802154_header_ie *p_header_ie);
+enum alif_mac154_status_code alif_mac154_ack_header_ie_set(uint16_t short_address,
+							   const uint8_t *p_extended_address,
+							   bool delete_ie,
+							   const struct alif_802154_header_ie *ie_info);
 
 /**
  * @brief Get promiscuous mode configuration

--- a/ieee802154/include/alif_mac154_def.h
+++ b/ieee802154/include/alif_mac154_def.h
@@ -198,4 +198,37 @@ struct alif_802154_frame_parser {
 	bool packet_ready;
 };
 
+#define VENDOR_IE_OUI_LENGTH 3
+
+struct alif_802154_header_ie_vendor_specific {
+	uint8_t vendor_oui[VENDOR_IE_OUI_LENGTH];
+	uint8_t *vendor_specific_info;
+};
+
+struct alif_802154_header_ie_rendezvous_time {
+	uint16_t rendezvous_time;
+	uint16_t wakeup_interval;
+	bool full_info;
+};
+
+struct alif_802154_header_ie_csl {
+	uint16_t csl_phase;
+	uint16_t csl_period;
+	uint16_t csl_rendezvous_time;
+	bool full_info;
+};
+
+struct alif_802154_header_ie {
+	uint16_t length;
+	uint16_t element_id_low;
+	uint16_t element_id_high;
+	uint16_t type;
+	uint8_t content_type;
+	union {
+		struct alif_802154_header_ie_vendor_specific vendor_specific;
+		struct alif_802154_header_ie_csl csl;
+		struct alif_802154_header_ie_rendezvous_time rendezvous_time;
+	} content;
+};
+
 #endif /* ALIF_MAC154_DEF_H_ */

--- a/ieee802154/src/alif_ahi.c
+++ b/ieee802154/src/alif_ahi.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 
 #include "alif_ahi.h"
+#include "es0_power_manager.h"
 
 #define LOG_MODULE_NAME alif_ahi
 

--- a/se_services/zephyr/include/se_service.h
+++ b/se_services/zephyr/include/se_service.h
@@ -15,6 +15,7 @@ int se_service_system_set_services_debug(bool debug_enable);
 int se_service_get_rnd_num(uint8_t *buffer, uint16_t length);
 int se_service_get_toc_number(uint32_t *ptoc);
 int se_service_get_se_revision(uint8_t *prev);
+int se_service_get_toc_version(uint32_t *pversion);
 int se_service_get_device_part_number(uint32_t *pdev_part);
 int se_service_system_get_device_data(get_device_revision_data_t *pdev_data);
 int se_system_get_eui_extension(bool is_eui48, uint8_t *eui_extension);


### PR DESCRIPTION
Moved IE element adaptation to RF driver and where is fix to vendor
data pointer configure.
SE service TOC version read update
ES0 power manager use synch for boot and check TOC version number for es0 shuttdown needs.