### PR TITLE
drivers: ospi: Handling RX underflow

### DIFF
--- a/drivers/ospi/src/ospi_hal.c
+++ b/drivers/ospi/src/ospi_hal.c
@@ -334,6 +334,7 @@ int32_t alif_hal_ospi_irq_handler(HAL_OSPI_Handle_T handle)
 	ospi_irq_handler(ospi_reg, &ospi_inst->transfer);
 
 	if (ospi_inst->transfer.status == SPI_TRANSFER_STATUS_COMPLETE) {
+
 		ospi_inst->transfer.status = SPI_TRANSFER_STATUS_NONE;
 
 		/* update event Status */
@@ -341,7 +342,9 @@ int32_t alif_hal_ospi_irq_handler(HAL_OSPI_Handle_T handle)
 						ospi_inst->user_data);
 	}
 
-	if (ospi_inst->transfer.status == SPI_TRANSFER_STATUS_OVERFLOW) {
+	if (ospi_inst->transfer.status == SPI_TRANSFER_STATUS_OVERFLOW ||
+		ospi_inst->transfer.status == SPI_TRANSFER_STATUS_RX_UNDERFLOW) {
+
 		ospi_inst->transfer.status = SPI_TRANSFER_STATUS_NONE;
 
 		/* update event Status */


### PR DESCRIPTION
RX_UNDER_FLOW handled as data lost.

Customer reported issue : [ZRTSS-489](https://alifsemi.atlassian.net/browse/ZRTSS-489)