### PR TITLE
common: Remove se_service_sync() call as unneeded

### DIFF
--- a/common/src/es0_power_manager.c
+++ b/common/src/es0_power_manager.c
@@ -122,8 +122,6 @@ int8_t take_es0_into_use(void)
 		int err;
 		uint32_t version;
 
-		/* Synch at boot allways */
-		se_service_sync();
 		err = se_service_get_toc_version(&version);
 		if (err) {
 			return err;


### PR DESCRIPTION
There is no need to call se_service_sync() in Balletto so this call is removed.