### PR TITLE
ble: fix utimer dependency

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -28,6 +28,7 @@ config ALIF_BLE_HOST
 	depends on HAS_ALIF_BLE_ROM_IMAGE
 	select FPU
 	select HAVE_CUSTOM_LINKER_SCRIPT
+	select USE_ALIF_HAL_UTIMER
 	help
 	  This option enables Alif Semiconductor's BLE Host Stack.
 


### PR DESCRIPTION
UTIMER is changed to depends on configuration flags. BLE configuration modified to select UTIMER by default.

Fixes the compilation issue after https://github.com/alifsemi/hal_alif/pull/19 merge.