### PR TITLE
We must use the same baudrate in LL configured to M55 UART

### DIFF
--- a/ble/plf/hci_uart.c
+++ b/ble/plf/hci_uart.c
@@ -167,3 +167,4 @@ bool hci_uart_flow_off(void)
 	/* TODO */
 	return true;
 }
+

--- a/common/include/es0_power_manager.h
+++ b/common/include/es0_power_manager.h
@@ -23,29 +23,33 @@ enum core_error_t {
 
 /**
  * @brief Register a user of a ES0
- * @return  -1 If too many users
- *          -2 If calculated size of boot params > 512
- *          -3 If calculated size of boot params differs from actual size.
- *          -4 Starting ES0 failed
+ * @param baudrate Baudrate used in host side will be passed to LL. All instances must
+ * 		   use same so once set it can only be changed by stopping all instances
+ * 		   first and then reinitialize with new value
+ * @retval  0 If successful
+ * @retval  -1 If too many users
+ * @retval  -2 If calculated size of boot params > 512
+ * @retval  -3 If calculated size of boot params differs from actual size.
+ * @retval  -4 Starting ES0 failed
+ * @retval  -5 Baudrate has not been set for HCI/AHI UARTs
+ * @retval  -6 Baudrate mismatch
  */
 int8_t take_es0_into_use(void);
 
 /**
  * @brief De-register a user of a ES0
- * @return  -1 If no active users
- *          -2 Shutdown of ES0 failed
+ * @retval  -1 If no active users
+ * @retval  -2 Shutdown of ES0 failed
  */
 int8_t stop_using_es0(void);
 
 /**
  * @brief wakeup ES0 using uart
- * 
+ *
  * ES0 needs to be woken once per boot and should then remain active
  * until ES1 is powered off.
- * 
+ *
  * This function can be called as many times during the boot.
- * 
- * @return 
  */
 void wake_es0(const struct device *uart_dev);
 

--- a/common/src/es0_power_manager.c
+++ b/common/src/es0_power_manager.c
@@ -63,6 +63,14 @@ static uint32_t wakeup_count;
 #define BOOT_PARAM_LEN_RM_WAKEUP_TIME            2
 #define BOOT_PARAM_LEN_EXT_WARMBOOT_WAKEUP_TIME  2
 
+#define ES0_PM_ERROR_NO_ERROR	 		 0
+#define ES0_PM_ERROR_TOO_MANY_USERS		 -1
+#define ES0_PM_ERROR_TOO_MANY_BOOT_PARAMS	 -2
+#define ES0_PM_ERROR_INVALID_BOOT_PARAMS	 -3
+#define ES0_PM_ERROR_START_FAILED		 -4
+#define ES0_PM_ERROR_NO_BAUDRATE		 -5
+#define ES0_PM_ERROR_BAUDRATE_MISMATCH		 -6
+
 static uint8_t *write_tlv_int(uint8_t *target, uint8_t tag, uint32_t value, uint8_t len)
 {
 	*target++ = tag;
@@ -115,8 +123,25 @@ static void alif_eui48_read(uint8_t *eui48)
 int8_t take_es0_into_use(void)
 {
 	if (255 == es0_user_counter) {
-		return -1;
+		return ES0_PM_ERROR_TOO_MANY_USERS;
 	}
+
+	uint32_t hci_baudrate;
+	uint32_t ahi_baudrate;
+	uint32_t used_baudrate;
+
+	hci_baudrate = DT_PROP_OR(DT_CHOSEN(zephyr_hci_uart), current_speed, 0);
+	ahi_baudrate = DT_PROP_OR(DT_CHOSEN(zephyr_ahi_uart), current_speed, 0);
+
+	if (!hci_baudrate && !ahi_baudrate) {
+		return ES0_PM_ERROR_NO_BAUDRATE;
+	}
+
+	if (hci_baudrate && ahi_baudrate && hci_baudrate != ahi_baudrate) {
+		return ES0_PM_ERROR_BAUDRATE_MISMATCH;
+	}
+
+	used_baudrate = hci_baudrate ? hci_baudrate : ahi_baudrate;
 
 	if (es0_user_counter == 0) {
 		int err;
@@ -134,7 +159,7 @@ int8_t take_es0_into_use(void)
 	} else {
 		/* Already started */
 		es0_user_counter++;
-		return 0;
+		return ES0_PM_ERROR_NO_ERROR;
 	}
 
 	static uint8_t ll_boot_params_buffer[LL_BOOT_PARAMS_MAX_SIZE];
@@ -162,7 +187,7 @@ int8_t take_es0_into_use(void)
 	total_length += (18 * 3); /* Each write_tlv_x call writes additional 3 bytes */
 
 	if (total_length > LL_BOOT_PARAMS_MAX_SIZE) {
-		return -2;
+		return ES0_PM_ERROR_TOO_MANY_BOOT_PARAMS;
 	}
 
 	uint8_t bd_address[BOOT_PARAM_LEN_BD_ADDRESS];
@@ -194,7 +219,7 @@ int8_t take_es0_into_use(void)
 			    BOOT_PARAM_LEN_ENABLE_CHANNEL_ASSESSMENT);
 	ptr = write_tlv_int(ptr, BOOT_PARAM_ID_RSSI_INTERF_THR, CONFIG_ALIF_PM_RSSI_INTERF_THR,
 			    BOOT_PARAM_LEN_RSSI_THR);
-	ptr = write_tlv_int(ptr, BOOT_PARAM_ID_UART_BAUDRATE, CONFIG_ALIF_PM_LL_UART_BAUDRATE,
+	ptr = write_tlv_int(ptr, BOOT_PARAM_ID_UART_BAUDRATE, used_baudrate,
 			    BOOT_PARAM_LEN_UART_BAUDRATE);
 	ptr = write_tlv_int(ptr, BOOT_PARAM_ID_EXT_WAKEUP_TIME, CONFIG_ALIF_EXT_WAKEUP_TIME,
 			    BOOT_PARAM_LEN_EXT_WAKEUP_TIME);
@@ -206,7 +231,7 @@ int8_t take_es0_into_use(void)
 			    CONFIG_ALIF_EXT_WARMBOOT_WAKEUP_TIME,
 			    BOOT_PARAM_LEN_EXT_WARMBOOT_WAKEUP_TIME);
 
-	uint32_t min_uart_clk_freq = CONFIG_ALIF_PM_LL_UART_BAUDRATE * 16;
+	uint32_t min_uart_clk_freq = used_baudrate * 16;
 	uint32_t reg_uart_clk_cfg = LL_UART_CLK_SEL_CTRL_16MHZ;
 	uint32_t ll_uart_clk_freq = 16000000;
 	uint32_t es0_clock_select = CONFIG_SE_SERVICE_RF_CORE_FREQUENCY;
@@ -232,15 +257,15 @@ int8_t take_es0_into_use(void)
 	}
 
 	if (total_length != (ptr - ll_boot_params_buffer)) {
-		return -3;
+		return ES0_PM_ERROR_INVALID_BOOT_PARAMS;
 	}
 
 	if (se_service_boot_es0(ll_boot_params_buffer, total_length, es0_clock_select)) {
-		return -4;
+		return ES0_PM_ERROR_START_FAILED;
 	}
 
 	es0_user_counter++;
-	return 0;
+	return ES0_PM_ERROR_NO_ERROR;
 }
 
 int8_t stop_using_es0(void)

--- a/common/zephyr/Kconfig
+++ b/common/zephyr/Kconfig
@@ -54,12 +54,6 @@ config ALIF_PM_RSSI_INTERF_THR
 	int "RSSI interference threshold"
 	default -70
 
-# TODO: change default to 3000000 in final product
-config ALIF_PM_LL_UART_BAUDRATE
-	int "UART baudrate between cores. Must match with application's baudrate"
-	range 115200 3000000
-	default 1000000
-
 config ALIF_EXT_WAKEUP_TIME
 	int "External wakeup time needed (us)"
 	default 25000


### PR DESCRIPTION
Baudrate needs to be passed when taking ES0 into use. We must use the same value which is used for M55 UART so in this PR the value is read from DTS before passing it to LL. We also need to check both HCI and AHI UARTs to match. It might be that only one of those was set so it was taken into account as well.

Parent PR: https://github.com/alifsemi/zephyr_alif/pull/102