### PR TITLE
common: restrict ns setup for Alif platform

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,8 +1,12 @@
-zephyr_include_directories(include)
+if(CONFIG_SOC_FAMILY_ENSEMBLE OR
+    CONFIG_SOC_FAMILY_BALLETTO)
 
-zephyr_library_sources(src/sau_tcm_ns_setup.c)
-zephyr_library_sources(src/tgu.c)
-zephyr_library_sources(src/system.c)
+  zephyr_include_directories(include)
+
+  zephyr_library_sources(src/sau_tcm_ns_setup.c)
+  zephyr_library_sources(src/tgu.c)
+  zephyr_library_sources(src/system.c)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_HAS_ALIF_POWER_MANAGER
     src/es0_power_manager.c


### PR DESCRIPTION
Build for other boards like qemu or native_sim
are failing as non-secure memory setup is not
needed for these. Restrict ns setup for Alif
platforms only to fix build for other boards.