### PR TITLE
ble: fix memcpy alignment issue for ISO data

### DIFF
--- a/ble/plf/alif_ble.c
+++ b/ble/plf/alif_ble.c
@@ -111,6 +111,13 @@ static void *global_to_local_rtss_he(void *global)
 	return global;
 }
 
+static void temp_memcpy(uint8_t *restrict p_dst, uint8_t *restrict p_src, size_t len)
+{
+	while (len--) {
+		*p_dst++ = *p_src++;
+	}
+}
+
 int32_t copy_without_dma(void *p_dst, void *p_src, size_t len, void (*cb)(uint32_t err))
 {
 	__ASSERT_NO_MSG(p_dst);
@@ -119,7 +126,12 @@ int32_t copy_without_dma(void *p_dst, void *p_src, size_t len, void (*cb)(uint32
 	void *p_dst_loc = global_to_local_rtss_he(p_dst);
 	void *p_src_loc = global_to_local_rtss_he(p_src);
 
-	memcpy(p_dst_loc, p_src_loc, len);
+	/* BLE RAM is handled as a DEVICE memory which disallows unaligned
+	 * accesses so the memcpy is not possible if the SDU size is not properly
+	 * aligned (e.g. 155 bytes).
+	 * Use custom memcpy for now while the DMA is not implemented.
+	 */
+	temp_memcpy(p_dst_loc, p_src_loc, len);
 
 	if (cb) {
 		cb(0);

--- a/ble/plf/sync_timer.c
+++ b/ble/plf/sync_timer.c
@@ -153,10 +153,11 @@ static void overflow_irq_handler(const void *context)
 {
 	(void)context;
 
-	LOG_DBG("ISO sync timer overflow IRQ handler");
+	/* LOG_DBG("ISO sync timer overflow IRQ handler"); */
 
 	/* Clear OVERFLOW IRQ */
 	UTIMER_CHAN(ISO_EVT_UTIMER_CHAN)->chan_interrupt |= UTIMER_OVERFLOW_BIT_MASK;
+	(void)UTIMER_CHAN(ISO_EVT_UTIMER_CHAN)->chan_interrupt;
 
 	if (sync_timer_ovf_cb) {
 		sync_timer_ovf_cb();
@@ -167,10 +168,11 @@ static void capture_irq_handler(const void *context)
 {
 	(void)context;
 
-	LOG_DBG("ISO sync timer capture IRQ handler");
+	/* LOG_DBG("ISO sync timer capture IRQ handler"); */
 
 	/* Clear CAPTURE A IRQ */
 	UTIMER_CHAN(ISO_EVT_UTIMER_CHAN)->chan_interrupt |= UTIMER_CAPTURE_A_BIT_MASK;
+	(void)UTIMER_CHAN(ISO_EVT_UTIMER_CHAN)->chan_interrupt;
 
 	if (sync_timer_cap_cb) {
 		sync_timer_cap_cb();
@@ -242,7 +244,7 @@ uint32_t sync_timer_start(void (*sync_timer_capture_evt_cb)(void),
 	/* Global timer channel enable */
 	((TIMER_RegInfo *)(UTIMER_BASE))->glb_cntr_start |= (1 << ISO_EVT_UTIMER_CHAN);
 
-	LOG_DBG("ISO sync timer started");
+	/* LOG_DBG("ISO sync timer started"); */
 
 	return CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
 }


### PR DESCRIPTION
memcpy could cause an issue when ISO SDU size is
unaligned. Use temporary while loop to avoid issue for now.