### PR TITLE
se_services: Fixes parsing mfg_data_v2_t

### DIFF
--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -41,18 +41,20 @@ typedef struct {
 
 /* Manufacturing data for Ensemble Family revision >= REV_B3 */
 typedef struct {
-	uint8_t x_loc: 7;
-	uint8_t zero_1: 1;
-	uint8_t y_loc: 7;
-	uint8_t zero_2: 1;
-	uint8_t wfr_id: 5;
-	uint8_t zero_3: 2;
-	uint8_t fab_id: 1;
 	uint8_t year: 6;
-	uint8_t zero_4: 2;
-	uint8_t week: 6;
-	uint8_t zero_5: 2;
+	uint8_t zero_1: 2;
+	uint8_t wfr_id: 5;
+	uint8_t zero_2: 2;
+	uint8_t fab_id: 1;
+	uint8_t y_loc: 7;
+	uint8_t zero_3: 1;
+	uint8_t x_loc: 7;
+	uint8_t zero_4: 1;
+	uint8_t zero_5: 8;
+	uint8_t zero_6: 8;
 	uint8_t lot_no: 8;
+	uint8_t week: 6;
+	uint8_t zero_7: 2;
 } mfg_data_v2_t;
 
 typedef union {


### PR DESCRIPTION
Updated mfg_data_v2_t structure to parse manufacture data properly.

This PR is referenced by https://github.com/alifsemi/zephyr_alif/pull/150