### PR TITLE
ble: v1_0: Fix BLE patch file path in CMakeLists

### DIFF
--- a/ble/v1_0/CMakeLists.txt
+++ b/ble/v1_0/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_include_directories(include)
 
-zephyr_link_libraries_ifdef(CONFIG_ALIF_BLE_HOST_PATCHING rom_ble_stack.patch.elf)
+zephyr_link_libraries_ifdef(CONFIG_ALIF_BLE_HOST_PATCHING ${CMAKE_CURRENT_SOURCE_DIR}/rom_ble_stack.patch.elf)


### PR DESCRIPTION
Fix the path of the BLE patch file in CMakeLists.