### PR TITLE
SE Service: Apply the RUN and OFF profiles

### DIFF
--- a/se_services/zephyr/Kconfig
+++ b/se_services/zephyr/Kconfig
@@ -17,3 +17,16 @@ config SE_SERVICE_RF_CORE_FREQUENCY
 	default 4
 	help
 	  Valid values are 0, 4, 12.
+
+config ALIF_SE_DTS_RUN_PROFILE
+	bool "Apply SE run profile from DTS at boot and resume"
+	depends on ARM_MHUV2
+	depends on $(dt_nodelabel_enabled,aipm_run)
+	default y
+	help
+	  When enabled, se_service reads child nodes from the aipm-run DTS
+	  node and applies the matching run profile automatically:
+	    - At cold boot, from se_service_mhuv2_nodes_init()
+	      (PRE_KERNEL_1, CONFIG_SE_SERVICE_INIT_PRIORITY, default 45).
+	    - In pre_device_resume PM notifier on wakeup from any PM state,
+	      before pm_resume_devices() is called.

--- a/se_services/zephyr/Kconfig
+++ b/se_services/zephyr/Kconfig
@@ -30,3 +30,18 @@ config ALIF_SE_DTS_RUN_PROFILE
 	      (PRE_KERNEL_1, CONFIG_SE_SERVICE_INIT_PRIORITY, default 45).
 	    - In pre_device_resume PM notifier on wakeup from any PM state,
 	      before pm_resume_devices() is called.
+
+config ALIF_SE_DTS_OFF_PROFILE
+	bool "Apply SE off profile from DTS on PM state entry"
+	depends on ARM_MHUV2
+	depends on $(dt_nodelabel_enabled,aipm_off)
+	default y
+	help
+	  When enabled, se_service reads child nodes from the aipm-off DTS
+	  node and applies the matching off_profile_t before the CPU enters
+	  a low-power state (SUSPEND_TO_RAM or SOFT_OFF). The profile is
+	  applied in the state_entry PM notifier, before the CPU is
+	  clock-gated or powered down.
+
+	  The aipm-off node is disabled by default in SoC DTSIs. Enable it
+	  in a board overlay alongside the power-state nodes it supports.

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -43,11 +43,11 @@ static atomic_t se_ready = ATOMIC_INIT(0);
 static run_profile_t cached_run_profile;
 static bool run_profile_initialized;
 
-#ifdef CONFIG_ALIF_SE_DTS_RUN_PROFILE
-
 /*
- * DTS string token to aipm.h enum dispatch macros.
+ * Dispatch macros shared by RUN and OFF profile features.
  */
+#if defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+
 #define _SE_DT_CAT_DCDC(t)      _SE_DT_DCDC_##t
 #define SE_DT_DCDC_MODE(t)      _SE_DT_CAT_DCDC(t)
 #define _SE_DT_DCDC_off         DCDC_MODE_OFF
@@ -59,6 +59,10 @@ static bool run_profile_initialized;
 #define SE_DT_AON_CLK(t)        _SE_DT_CAT_AON_CLK(t)
 #define _SE_DT_AON_CLK_lfrc     CLK_SRC_LFRC
 #define _SE_DT_AON_CLK_lfxo     CLK_SRC_LFXO
+
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE || CONFIG_ALIF_SE_DTS_OFF_PROFILE */
+
+#ifdef CONFIG_ALIF_SE_DTS_RUN_PROFILE
 
 #define _SE_DT_CAT_RUN_CLK(t)   _SE_DT_RUN_CLK_##t
 #define SE_DT_RUN_CLK(t)        _SE_DT_CAT_RUN_CLK(t)
@@ -171,6 +175,97 @@ static void se_service_run_profile_pre_device_resume(enum pm_state state)
 }
 
 #endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE */
+
+#ifdef CONFIG_ALIF_SE_DTS_OFF_PROFILE
+
+#define AIPM_OFF_NODE DT_NODELABEL(aipm_off)
+
+struct aipm_off_profile_entry {
+	enum pm_state state;
+	uint8_t       substate;
+	off_profile_t profile;
+};
+
+/* stby-clk-src */
+#define _SE_DT_CAT_STBY_CLK(t)     _SE_DT_STBY_CLK_##t
+#define SE_DT_STBY_CLK(t)          _SE_DT_CAT_STBY_CLK(t)
+#define _SE_DT_STBY_CLK_hfrc       CLK_SRC_HFRC
+#define _SE_DT_STBY_CLK_hfxo       CLK_SRC_HFXO
+#define _SE_DT_STBY_CLK_pll        CLK_SRC_PLL
+
+/*
+ * Expand one aipm-off child node into an aipm_off_profile_entry initialiser.
+ * vtor_address is read from the parent node property — a compile-time
+ * constant set to the image's default boot address in the SoC DTSI.
+ */
+#define AIPM_OFF_CHILD_ENTRY(node_id) {					\
+	.state    = (enum pm_state)DT_PROP(node_id, pm_state),		\
+	.substate = (uint8_t)DT_PROP_OR(node_id, pm_substate, 0),	\
+	.profile  = {							\
+		.power_domains   = DT_PROP_OR(node_id,			\
+				       aipm_power_domains, 0),		\
+		.dcdc_voltage    = DT_PROP_OR(node_id,			\
+				       dcdc_voltage, 825),		\
+		.dcdc_mode       = SE_DT_DCDC_MODE(DT_STRING_TOKEN_OR(	\
+				       node_id, dcdc_mode, off)),	\
+		.aon_clk_src     = SE_DT_AON_CLK(DT_STRING_TOKEN_OR(	\
+				       node_id, aon_clk_src, lfxo)),	\
+		.stby_clk_src    = SE_DT_STBY_CLK(DT_STRING_TOKEN_OR(	\
+				       node_id, stby_clk_src, hfrc)),	\
+		.stby_clk_freq   = (scaled_clk_freq_t)DT_PROP_OR(	\
+				       node_id, stby_clk_freq,		\
+				       ALIF_SCALED_FREQ_RC_STDBY_76_8_MHZ), \
+		.memory_blocks   = DT_PROP_OR(node_id, memory_blocks, 0), \
+		.ip_clock_gating = DT_PROP_OR(node_id,			\
+				       ip_clock_gating, 0),		\
+		.phy_pwr_gating  = DT_PROP_OR(node_id,			\
+				       phy_pwr_gating, 0),		\
+		.vdd_ioflex_3V3  = (ioflex_mode_t)DT_PROP_OR(node_id,	\
+				       vdd_ioflex, ALIF_IOFLEX_LEVEL_1V8), \
+		.wakeup_events   = DT_PROP_OR(node_id,			\
+				       wakeup_events, 0),		\
+		.ewic_cfg        = DT_PROP_OR(node_id, ewic_cfg, 0),	\
+		.vtor_address    = DT_PROP(DT_PARENT(node_id),		\
+				       vtor_address),			\
+		.vtor_address_ns = 0,					\
+	},								\
+},
+
+/*
+ * Compile-time lookup table for off profiles.
+ */
+static const struct aipm_off_profile_entry aipm_off_profiles[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY(AIPM_OFF_NODE, AIPM_OFF_CHILD_ENTRY)
+};
+
+/*
+ * Find and apply the DTS off profile matching (state, substate_id).
+ * Called from the state_entry PM notifier before the CPU enters low-power.
+ * Copies the const entry to a local so se_service_set_off_cfg (non-const ptr)
+ * can be called cleanly.
+ */
+static void se_service_apply_off_profile_for_state(enum pm_state state,
+						   uint8_t substate_id)
+{
+	for (int i = 0; i < ARRAY_SIZE(aipm_off_profiles); i++) {
+		if (aipm_off_profiles[i].state   == state &&
+		    aipm_off_profiles[i].substate == substate_id) {
+			off_profile_t p = aipm_off_profiles[i].profile;
+			int err = se_service_set_off_cfg(&p);
+
+			if (err) {
+				LOG_ERR("aipm: set_off_cfg failed"
+					" (state %d/%d): %d",
+					state, substate_id, err);
+			}
+			return;
+		}
+	}
+	LOG_DBG("aipm: no off profile for state %d/%d; skipping",
+		state, substate_id);
+}
+
+#endif /* CONFIG_ALIF_SE_DTS_OFF_PROFILE */
 
 /* Manufacturing data for older Ensemble Family revision <= REV_B2 */
 typedef struct {
@@ -1530,6 +1625,15 @@ int se_service_clock_set_divider(clock_divider_t divider, uint32_t value)
  */
 static void se_service_pm_notify_entry(enum pm_state state)
 {
+#ifdef CONFIG_ALIF_SE_DTS_OFF_PROFILE
+	{
+		const struct pm_state_info *info = pm_state_next_get(0);
+
+		se_service_apply_off_profile_for_state(info->state,
+						       info->substate_id);
+	}
+#endif
+
 	switch (state) {
 	case PM_STATE_SUSPEND_TO_RAM:
 	case PM_STATE_SOFT_OFF:

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -6,6 +6,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/dt-bindings/misc/alif_aipm_common.h>
 #include <se_service.h>
 #include <soc_memory_map.h>
 #include <zephyr/logging/log.h>
@@ -41,6 +42,135 @@ static atomic_t se_ready = ATOMIC_INIT(0);
  */
 static run_profile_t cached_run_profile;
 static bool run_profile_initialized;
+
+#ifdef CONFIG_ALIF_SE_DTS_RUN_PROFILE
+
+/*
+ * DTS string token to aipm.h enum dispatch macros.
+ */
+#define _SE_DT_CAT_DCDC(t)      _SE_DT_DCDC_##t
+#define SE_DT_DCDC_MODE(t)      _SE_DT_CAT_DCDC(t)
+#define _SE_DT_DCDC_off         DCDC_MODE_OFF
+#define _SE_DT_DCDC_pfm_auto    DCDC_MODE_PFM_AUTO
+#define _SE_DT_DCDC_pfm_forced  DCDC_MODE_PFM_FORCED
+#define _SE_DT_DCDC_pwm         DCDC_MODE_PWM
+
+#define _SE_DT_CAT_AON_CLK(t)   _SE_DT_AON_CLK_##t
+#define SE_DT_AON_CLK(t)        _SE_DT_CAT_AON_CLK(t)
+#define _SE_DT_AON_CLK_lfrc     CLK_SRC_LFRC
+#define _SE_DT_AON_CLK_lfxo     CLK_SRC_LFXO
+
+#define _SE_DT_CAT_RUN_CLK(t)   _SE_DT_RUN_CLK_##t
+#define SE_DT_RUN_CLK(t)        _SE_DT_CAT_RUN_CLK(t)
+#define _SE_DT_RUN_CLK_hfrc     CLK_SRC_HFRC
+#define _SE_DT_RUN_CLK_hfxo     CLK_SRC_HFXO
+#define _SE_DT_RUN_CLK_pll      CLK_SRC_PLL
+
+#define AIPM_RUN_NODE DT_NODELABEL(aipm_run)
+
+struct aipm_profile_entry {
+	bool          is_default; /* true = no pm-state property = cold-boot default */
+	enum pm_state state;
+	uint8_t       substate;
+	run_profile_t profile;
+};
+
+/*
+ * Expand one aipm-run child node into an aipm_profile_entry
+ * initialiser.
+ */
+#define AIPM_CHILD_ENTRY(node_id) {						\
+	.is_default = !DT_NODE_HAS_PROP(node_id, pm_state),			\
+	.state      = (enum pm_state)DT_PROP_OR(node_id, pm_state, 0),		\
+	.substate   = (uint8_t)DT_PROP_OR(node_id, pm_substate, 0),		\
+	.profile = {								\
+		.power_domains   = DT_PROP_OR(node_id, aipm_power_domains,	\
+				   (PD_SSE700_AON_MASK | PD_SYST_MASK)),	\
+		.dcdc_voltage    = DT_PROP_OR(node_id, dcdc_voltage, 825),	\
+		.dcdc_mode       = SE_DT_DCDC_MODE(DT_STRING_TOKEN_OR(		\
+				       node_id, dcdc_mode, pwm)),		\
+		.aon_clk_src     = SE_DT_AON_CLK(DT_STRING_TOKEN_OR(		\
+				       node_id, aon_clk_src, lfxo)),		\
+		.run_clk_src     = SE_DT_RUN_CLK(DT_STRING_TOKEN_OR(		\
+				       node_id, clk_src, pll)),			\
+		.cpu_clk_freq    = (clock_frequency_t)DT_PROP(node_id,		\
+				       cpu_clk_freq),				\
+		.scaled_clk_freq = (scaled_clk_freq_t)DT_PROP_OR(		\
+				       node_id, scaled_clk_freq,		\
+				       ALIF_SCALED_FREQ_RC_ACTIVE_76_8_MHZ),	\
+		.memory_blocks   = DT_PROP_OR(node_id, memory_blocks, 0),	\
+		.ip_clock_gating = DT_PROP_OR(node_id, ip_clock_gating, 0),	\
+		.phy_pwr_gating  = DT_PROP_OR(node_id, phy_pwr_gating, 0),	\
+		.vdd_ioflex_3V3  = (ioflex_mode_t)DT_PROP_OR(node_id,		\
+				       vdd_ioflex, ALIF_IOFLEX_LEVEL_1V8),	\
+	},									\
+},
+
+/*
+ * Compile-time lookup table
+ */
+static const struct aipm_profile_entry aipm_profiles[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY(AIPM_RUN_NODE, AIPM_CHILD_ENTRY)
+};
+
+/*
+ * Apply the DTS run profile for a given (state, substate_id).
+ *
+ * Scans aipm_profiles[] for a matching (state, substate) child.  Falls back
+ * to the default child (is_default = true) if no match found.  No-op if
+ * run_profile_initialized is already true (avoids overwriting an app-set
+ * profile).
+ */
+static void se_service_apply_run_profile_for_state(enum pm_state state,
+					       uint8_t substate_id)
+{
+	const run_profile_t *default_profile = NULL;
+	const run_profile_t *match = NULL;
+
+	if (run_profile_initialized) {
+		return;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(aipm_profiles); i++) {
+		if (aipm_profiles[i].is_default) {
+			default_profile = &aipm_profiles[i].profile;
+		} else if (aipm_profiles[i].state   == state &&
+			   aipm_profiles[i].substate == substate_id) {
+			match = &aipm_profiles[i].profile;
+			break;
+		}
+	}
+
+	const run_profile_t *selected = match ? match : default_profile;
+
+	if (!selected) {
+		LOG_WRN("aipm: no run profile for state %d/%d; skipping",
+			state, substate_id);
+		return;
+	}
+
+	/* profile is not modified */
+	int err = se_service_set_run_cfg((run_profile_t *)selected);
+
+	if (err) {
+		LOG_ERR("aipm: set_run_cfg failed (state %d/%d): %d",
+			state, substate_id, err);
+	}
+}
+
+/*
+ * PM resume: re-apply the run profile before peripheral drivers wake up.
+ * Called from pm_state_notify_pre_resume() before pm_resume_devices().
+ */
+static void se_service_run_profile_pre_device_resume(enum pm_state state)
+{
+	ARG_UNUSED(state);
+	const struct pm_state_info *info = pm_state_next_get(0);
+
+	se_service_apply_run_profile_for_state(info->state, info->substate_id);
+}
+
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE */
 
 /* Manufacturing data for older Ensemble Family revision <= REV_B2 */
 typedef struct {
@@ -1448,7 +1578,15 @@ static int se_service_mhuv2_nodes_init(void)
 
 	/* Register PM notifier to handle suspend/resume */
 	se_pm_notifier.state_entry = se_service_pm_notify_entry;
+#ifdef CONFIG_ALIF_SE_DTS_RUN_PROFILE
+	se_pm_notifier.pre_device_resume = se_service_run_profile_pre_device_resume;
+#endif
 	pm_notifier_register(&se_pm_notifier);
+
+#ifdef CONFIG_ALIF_SE_DTS_RUN_PROFILE
+	/* Cold boot: apply the DTS default run profile now that MHUv2 is up. */
+	se_service_apply_run_profile_for_state(PM_STATE_ACTIVE, 0);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Below features are implemented in this,

1) Apply the SE OFF profiles from DTS before the CPU enters low-power states.
2) Apply the SE RUN profile from the aipm-run DTS node, removing the need for application-level SYS_INIT to call se_service_set_run_cfg().  
