### PR TITLE
se_service: Add API to enable power domain

### DIFF
--- a/se_services/zephyr/include/se_service.h
+++ b/se_services/zephyr/include/se_service.h
@@ -328,6 +328,23 @@ int se_service_process_toc_entry(const char *image_id);
  */
 int se_service_read_otp(uint32_t otp_offset, uint32_t *otp_word);
 
+/**
+ * @brief Enable a power domain via SE service run configuration.
+ *
+ * Performs a read-modify-write on the last set run profile to enable the
+ * specified power domain. Safe to call before the power domain driver is
+ * initialized (e.g. from a PM notifier pre_device_resume callback).
+ *
+ * @param pd_id Power domain bit index (ALIF_PD_* from alif_power_domain.h)
+ * @retval 0 on success
+ * @retval -EINVAL Invalid pd_id (must be < 32).
+ * @retval -ENODATA Profile cache is not initialized.
+ * @retval -EAGAIN Operation timed out. Retry after a delay.
+ * @retval -EBUSY SE is busy. Retry after a delay.
+ * @return Positive error code returned by SE for a failed service request.
+ */
+int se_service_enable_pd(uint32_t pd_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -1709,6 +1709,46 @@ int se_service_read_otp(uint32_t otp_offset, uint32_t *otp_word)
 	return 0;
 }
 
+int se_service_enable_pd(uint32_t pd_id)
+{
+	run_profile_t runp;
+	int ret;
+
+	if (pd_id >= 32) {  /* power_domains is a uint32_t bitmask */
+		return -EINVAL;
+	}
+
+	/* Ensure SE is ready to receive service calls */
+	ret = se_service_ensure_ready();
+	if (ret) {
+		return ret;
+	}
+
+	ret = k_mutex_lock(&svc_mutex, K_MSEC(MUTEX_TIMEOUT));
+
+	if (ret) {
+		LOG_ERR("Unable to lock mutex (err = %d)\n", ret);
+		return ret;
+	}
+
+	ret = se_service_get_last_set_run_cfg(&runp);
+	if (ret) {
+		goto out;
+	}
+
+	if (runp.power_domains & BIT(pd_id)) {
+		ret = 0;
+		goto out;
+	}
+
+	runp.power_domains |= BIT(pd_id);
+	ret = se_service_set_run_cfg(&runp);
+
+out:
+	k_mutex_unlock(&svc_mutex);
+	return ret;
+}
+
 /**
  * @brief PM notifier callback for SE service state entry
  *


### PR DESCRIPTION
Introduce se_service_enable_pd() to enable a power domain via SE service run config.

It is safe to call this API before the power domain driver is initialized (e.g., from a PM notifier pre_device_resume callback)