### PR TITLE
drivers: isp: Fix AWB Auto mode initialization

### DIFF
--- a/drivers/isp/isp_wrapper/inc/isp_param_conf.h
+++ b/drivers/isp/isp_wrapper/inc/isp_param_conf.h
@@ -57,8 +57,8 @@ static ISP_CALIB_DATA_S isp_calib_param = {
 			.blockWin = {
 				.hOffs = 0,
 				.vOffs = 0,
-				.hSize = 1920,
-				.vSize = 1080,
+				.hSize = 560,
+				.vSize = 560,
 			},
 		},
 #endif /* defined(CONFIG_ISP_LIB_EXPOSUREM_MODULE) */
@@ -67,34 +67,34 @@ static ISP_CALIB_DATA_S isp_calib_param = {
 		.ae = {
 			.opType = OP_TYPE_AUTO,
 			.manualAttr = {
-				.intTime = 100000,
-				.again = 75000,
-				.dgain = 256,
+				.intTime = 73470,
+				.again = 10240,
+				.dgain = 1024,
 			},
 			.autoAttr = {
 				.expTimeRange = {
 					.min =  100,
-					.max =  3000000,
+					.max =  200000,
 				},
 				.againRange = {
-					.min = 1 * 1024,
-					.max = 8 * 1024,
+					.min = 10 * 1024,
+					.max = 80 * 1024,
 				},
 				.dgainRange = {
 					.min = 1 * 1024,
 					.max = 8 * 1024,
 				},
 				.aeRunInterval = 1,
-				.aeTarget = 255,
+				.aeTarget = 100,
 				.dampOver = 0x40,
 				.dampUnder = 0x40,
-				.tolerance = 1,
+				.tolerance = 10,
 				.antiflicker = {
 					.enable = 0,
 					.flickerFreq = 100,
 				},
 				.aeMode = AE_MODE_FIX_FRAME_RATE,
-				.gainThreshold = 1024,
+				.gainThreshold = 12000,
 				.aeRoute = {
 					.totalNum = 0,
 				},

--- a/drivers/isp/isp_wrapper/inc/isp_param_conf.h
+++ b/drivers/isp/isp_wrapper/inc/isp_param_conf.h
@@ -57,8 +57,8 @@ static ISP_CALIB_DATA_S isp_calib_param = {
 			.blockWin = {
 				.hOffs = 0,
 				.vOffs = 0,
-				.hSize = 1920,
-				.vSize = 1080,
+				.hSize = 560,
+				.vSize = 560,
 			},
 		},
 #endif /* defined(CONFIG_ISP_LIB_EXPOSUREM_MODULE) */
@@ -67,34 +67,34 @@ static ISP_CALIB_DATA_S isp_calib_param = {
 		.ae = {
 			.opType = OP_TYPE_AUTO,
 			.manualAttr = {
-				.intTime = 100000,
-				.again = 75000,
-				.dgain = 256,
+				.intTime = 73470,
+				.again = 10 * 1024,
+				.dgain = 1 * 1024,
 			},
 			.autoAttr = {
 				.expTimeRange = {
 					.min =  100,
-					.max =  3000000,
+					.max =  200000,
 				},
 				.againRange = {
-					.min = 1 * 1024,
-					.max = 8 * 1024,
+					.min = 10 * 1024,
+					.max = 80 * 1024,
 				},
 				.dgainRange = {
 					.min = 1 * 1024,
 					.max = 8 * 1024,
 				},
 				.aeRunInterval = 1,
-				.aeTarget = 255,
+				.aeTarget = 100,
 				.dampOver = 0x40,
 				.dampUnder = 0x40,
-				.tolerance = 1,
+				.tolerance = 10,
 				.antiflicker = {
 					.enable = 0,
 					.flickerFreq = 100,
 				},
 				.aeMode = AE_MODE_FIX_FRAME_RATE,
-				.gainThreshold = 1024,
+				.gainThreshold = 12000,
 				.aeRoute = {
 					.totalNum = 0,
 				},

--- a/drivers/isp/isp_wrapper/inc/sensor_attributes.h
+++ b/drivers/isp/isp_wrapper/inc/sensor_attributes.h
@@ -17,24 +17,24 @@ static AE_SNS_DEFAULT_S sensor_attributes = {
 	.fullLines = 0xA47B,
 	.fps = 5 * ISP_SNS_FPS_ACCU,
 	.maxIntLine = 0xA478,
-	.minIntLine = 0x1,
+	.minIntLine = 0x3,
 	.intLineStep = 1,
-	.maxAgain = 0x80000,
-	.minAgain = 0x10000,
+	.maxAgain = 80 * 1024,
+	.minAgain = 10 * 1024,
 	.againStep = 1,
-	.maxDgain = 0x1FF,
-	.minDgain = 64,
+	.maxDgain = 8 * 1024,
+	.minDgain = 1 * 1024,
 	.dgainStep = 1,
 	.aeRunInterval = 1,
-	.aeTarget = 50,
+	.aeTarget = 100,
 
 	.dampOver = 0x40,
 	.dampUnder = 0x40,
-	.tolerance = 1,
+	.tolerance = 10,
 
-	.initExposure = 80,
+	.initExposure = 100000,
 	.aeMode = AE_MODE_FIX_FRAME_RATE,
-	.gainThreshold = 1024,
+	.gainThreshold = 10 * 1024,
 };
 
 #ifdef __cplusplus

--- a/drivers/isp/isp_wrapper/src/isp_api_wrapper.c
+++ b/drivers/isp/isp_wrapper/src/isp_api_wrapper.c
@@ -367,6 +367,12 @@ int isp_vsi_init(struct isp_config_params *init_cfg)
 		return isp_err_2_errno(ret);
 	}
 
+	ret = VSI_MPI_ISP_SetCalib(isp_port_id, &isp_calib_param);
+	if (ret) {
+		LOG_ERR("Writing calibration data before Initialization of AWB Algo!");
+		return isp_err_2_errno(ret);
+	}
+
 	/* Program the function pointers for AWB Algorithm in library */
 #if defined(CONFIG_ISP_LIB_WB_MODULE)
 	ret = VSI_MPI_ISP_AwbRegCallBack(isp_port_id, &vsiAwbAlgo);
@@ -715,15 +721,15 @@ int isp_vsi_start(struct isp_config_params *init_cfg)
 		return isp_err_2_errno(ret);
 	}
 
-	ret = VSI_MPI_ISP_EnablePort(isp_port_id);
-	if (ret) {
-		LOG_ERR("Failed to enable ISP Port!");
-		return isp_err_2_errno(ret);
-	}
-
 	ret = VSI_MPI_ISP_EnableChn(isp_chn_id);
 	if (ret) {
 		LOG_ERR("Failed to enable ISP Channel!");
+		return isp_err_2_errno(ret);
+	}
+
+	ret = VSI_MPI_ISP_EnablePort(isp_port_id);
+	if (ret) {
+		LOG_ERR("Failed to enable ISP Port!");
 		return isp_err_2_errno(ret);
 	}
 
@@ -759,6 +765,12 @@ int isp_vsi_stop(struct isp_config_params *init_cfg)
 	isp_chn_id.portId = port->port_id;
 	isp_chn_id.chnId = channel->channel_idx;
 
+	ret = VSI_MPI_ISP_DisablePort(isp_port_id);
+	if (ret) {
+		LOG_ERR("Failed to disable ISP Port!");
+		return isp_err_2_errno(ret);
+	}
+
 	ret = VSI_MPI_ISP_DisableChn(isp_chn_id);
 	if (ret) {
 		LOG_ERR("Failed to disable ISP Channel!");
@@ -768,12 +780,6 @@ int isp_vsi_stop(struct isp_config_params *init_cfg)
 	ret = VSI_MPI_ISP_DisableDev(isp_dev_id);
 	if (ret) {
 		LOG_ERR("Failed to disable ISP Device!");
-		return isp_err_2_errno(ret);
-	}
-
-	ret = VSI_MPI_ISP_DisablePort(isp_port_id);
-	if (ret) {
-		LOG_ERR("Failed to disable ISP Port!");
 		return isp_err_2_errno(ret);
 	}
 

--- a/drivers/isp/isp_wrapper/src/isp_api_wrapper.c
+++ b/drivers/isp/isp_wrapper/src/isp_api_wrapper.c
@@ -367,6 +367,12 @@ int isp_vsi_init(struct isp_config_params *init_cfg)
 		return isp_err_2_errno(ret);
 	}
 
+	ret = VSI_MPI_ISP_SetCalib(isp_port_id, &isp_calib_param);
+	if (ret) {
+		LOG_ERR("Failed to set calibration data before registering AE/AWB algorithms!");
+		return isp_err_2_errno(ret);
+	}
+
 	/* Program the function pointers for AWB Algorithm in library */
 #if defined(CONFIG_ISP_LIB_WB_MODULE)
 	ret = VSI_MPI_ISP_AwbRegCallBack(isp_port_id, &vsiAwbAlgo);
@@ -715,15 +721,15 @@ int isp_vsi_start(struct isp_config_params *init_cfg)
 		return isp_err_2_errno(ret);
 	}
 
-	ret = VSI_MPI_ISP_EnablePort(isp_port_id);
-	if (ret) {
-		LOG_ERR("Failed to enable ISP Port!");
-		return isp_err_2_errno(ret);
-	}
-
 	ret = VSI_MPI_ISP_EnableChn(isp_chn_id);
 	if (ret) {
 		LOG_ERR("Failed to enable ISP Channel!");
+		return isp_err_2_errno(ret);
+	}
+
+	ret = VSI_MPI_ISP_EnablePort(isp_port_id);
+	if (ret) {
+		LOG_ERR("Failed to enable ISP Port!");
 		return isp_err_2_errno(ret);
 	}
 
@@ -759,6 +765,12 @@ int isp_vsi_stop(struct isp_config_params *init_cfg)
 	isp_chn_id.portId = port->port_id;
 	isp_chn_id.chnId = channel->channel_idx;
 
+	ret = VSI_MPI_ISP_DisablePort(isp_port_id);
+	if (ret) {
+		LOG_ERR("Failed to disable ISP Port!");
+		return isp_err_2_errno(ret);
+	}
+
 	ret = VSI_MPI_ISP_DisableChn(isp_chn_id);
 	if (ret) {
 		LOG_ERR("Failed to disable ISP Channel!");
@@ -768,12 +780,6 @@ int isp_vsi_stop(struct isp_config_params *init_cfg)
 	ret = VSI_MPI_ISP_DisableDev(isp_dev_id);
 	if (ret) {
 		LOG_ERR("Failed to disable ISP Device!");
-		return isp_err_2_errno(ret);
-	}
-
-	ret = VSI_MPI_ISP_DisablePort(isp_port_id);
-	if (ret) {
-		LOG_ERR("Failed to disable ISP Port!");
 		return isp_err_2_errno(ret);
 	}
 


### PR DESCRIPTION
AWB in Auto mode was not initializing. Call VSI_MPI_ISP_SetCalib() before registering the AE and AWB algorithms, and again after algorithm registration following VSI_MPI_ISP_SetPortAttr(). This ensures that AWB initializes properly in auto mode.
Also fix calibration parameters to valid range.

This PR depends on: alifsemi/zephyr_alif/pull/597