### PR TITLE
common: Set default values for B1 DK LPA mode

### DIFF
--- a/common/zephyr/Kconfig
+++ b/common/zephyr/Kconfig
@@ -100,7 +100,7 @@ config ALIF_TX_MAX_POWER
 
 config ALIF_EDGE_LIMIT_ON
 	bool # "Limit power on edge channels"
-	default y if BOARD_ALIF_B1_DK
+	default y if (BOARD_ALIF_B1_DK && !ALIF_HPA_MODE)
 	default n
 
 config ALIF_EDGE_LOW_CHANNEL
@@ -109,12 +109,12 @@ config ALIF_EDGE_LOW_CHANNEL
 
 config ALIF_EDGE_HIGH_CHANNEL
 	int "Last channel the edge limit is not applied"
-	default 38 if BOARD_ALIF_B1_DK
+	default 37 if (BOARD_ALIF_B1_DK && !ALIF_HPA_MODE)
 	default 39
 
 config ALIF_EDGE_CHANNEL_POWER_LIMIT
 	int "Set maximum allowed TX power in dBm for edges"
-	default 0 if BOARD_ALIF_B1_DK
+	default 2 if (BOARD_ALIF_B1_DK && !ALIF_HPA_MODE)
 	default ALIF_TX_MAX_POWER
 	range ALIF_TX_MIN ALIF_TX_MAX_POWER
 


### PR DESCRIPTION
In B1 DK using LPA mode we must limit channels 38 & 39 power to 2 dBm.