### PR TITLE
ble/lc3: allow the ROM API to be supplied by another module

### DIFF
--- a/ble/CMakeLists.txt
+++ b/ble/CMakeLists.txt
@@ -9,4 +9,14 @@ zephyr_sources(
   plf/sync_timer.c
 )
 
-add_subdirectory_ifdef(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2 v1_2)
+if(CONFIG_ALIF_BLE_ROM_API_EXTERNAL)
+  # An out-of-tree module supplies the BLE ROM API: the public headers, the ROM
+  # symbol-address linker script and the host-stack patch. Expose the generic
+  # patch section placement scripts from this HAL directory so the provider only
+  # has to ship its headers, symbol addresses and patch ELF.
+  set(ALIF_BLE_ROM_PATCH_LD_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  string(CONFIGURE "${CONFIG_ALIF_BLE_ROM_API_DIR}" ALIF_BLE_ROM_API_DIR)
+  add_subdirectory(${ALIF_BLE_ROM_API_DIR} ble_rom_api_ext)
+else()
+  add_subdirectory_ifdef(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2 v1_2)
+endif()

--- a/lc3/CMakeLists.txt
+++ b/lc3/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_subdirectory_ifdef(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2 v1_2)
+if(CONFIG_ALIF_BLE_ROM_API_EXTERNAL)
+  string(CONFIGURE "${CONFIG_ALIF_LC3_ROM_API_DIR}" ALIF_LC3_ROM_API_DIR)
+  add_subdirectory(${ALIF_LC3_ROM_API_DIR} lc3_rom_api_ext)
+else()
+  add_subdirectory_ifdef(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2 v1_2)
+endif()

--- a/linker_add_rom_symbols.ld
+++ b/linker_add_rom_symbols.ld
@@ -13,7 +13,14 @@
 
 /* Symbols in ROM */
 
-#if defined(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2) && CONFIG_ALIF_BLE_ROM_IMAGE_V1_2
+#if defined(CONFIG_ALIF_BLE_ROM_API_EXTERNAL) && CONFIG_ALIF_BLE_ROM_API_EXTERNAL
+/* BLE/LC3 ROM symbol addresses supplied by an out-of-tree module (see
+ * ALIF_BLE_ROM_API_* Kconfig). The paths are absolute and resolved from those
+ * config strings. Takes precedence over the bundled set so a board can override
+ * the default. */
+#include CONFIG_ALIF_LC3_ROM_SYMBOLS_LDS
+#include CONFIG_ALIF_BLE_ROM_SYMBOLS_LDS
+#elif defined(CONFIG_ALIF_BLE_ROM_IMAGE_V1_2) && CONFIG_ALIF_BLE_ROM_IMAGE_V1_2
 #include "lc3/v1_2/rom_symbols_lc3.lds"
 #include "ble/v1_2/rom_symbols_ble.lds"
 #else

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -44,6 +44,58 @@ config CUSTOM_LINKER_SCRIPT
 
 endif # HAVE_CUSTOM_LINKER_SCRIPT
 
+# BLE/LC3 ROM API source selection.
+#
+# Alif BLE and LC3 run from code resident in the SoC ROM. This HAL does not ship
+# that ROM; it ships the means to call into it: the public API headers, the ROM
+# symbol-address linker scripts and the host-stack patch overlay. By default the
+# set bundled in this HAL is used, selected from the device tree ble-rom-version
+# property. An out-of-tree module can instead supply these files by selecting
+# ALIF_BLE_ROM_API_EXTERNAL and pointing the options below at them, so a module
+# can carry its own API headers and symbol addresses while reusing this HAL's
+# build and link machinery.
+config ALIF_BLE_ROM_API_EXTERNAL
+	bool "Take the BLE/LC3 ROM API and symbol addresses from an out-of-tree module"
+	depends on HAS_ALIF_BLE_ROM_IMAGE
+	help
+	  Use the BLE/LC3 ROM API headers, ROM symbol-address linker scripts and
+	  host-stack patch supplied by another module instead of the set bundled in
+	  this HAL. The on-chip ROM itself is unchanged; only the interface used to
+	  call into it is provided. When enabled, set ALIF_BLE_ROM_API_DIR,
+	  ALIF_LC3_ROM_API_DIR, ALIF_BLE_ROM_SYMBOLS_LDS and ALIF_LC3_ROM_SYMBOLS_LDS
+	  to the providing module's files. Typically selected from a board's
+	  Kconfig.defconfig.
+
+if ALIF_BLE_ROM_API_EXTERNAL
+
+config ALIF_BLE_ROM_API_DIR
+	string "External BLE ROM API directory"
+	help
+	  Directory added with add_subdirectory(). Must contain a CMakeLists.txt
+	  that exposes the BLE public API headers, links the host-stack patch
+	  (rom_ble_stack.patch.elf) and wires the patch sections (see this HAL's
+	  ble/v1_2 for the layout).
+
+config ALIF_LC3_ROM_API_DIR
+	string "External LC3 ROM API directory"
+	help
+	  Directory added with add_subdirectory(). Must contain a CMakeLists.txt
+	  that exposes the LC3 public API headers.
+
+config ALIF_BLE_ROM_SYMBOLS_LDS
+	string "External BLE ROM symbol-address linker script"
+	help
+	  Absolute path to the BLE ROM symbol-address linker script
+	  (rom_symbols_ble.lds), #included by linker_add_rom_symbols.ld.
+
+config ALIF_LC3_ROM_SYMBOLS_LDS
+	string "External LC3 ROM symbol-address linker script"
+	help
+	  Absolute path to the LC3 ROM symbol-address linker script
+	  (rom_symbols_lc3.lds), #included by linker_add_rom_symbols.ld.
+
+endif # ALIF_BLE_ROM_API_EXTERNAL
+
 rsource "../se_services/zephyr/Kconfig"
 rsource "../common/zephyr/Kconfig"
 rsource "../lc3/zephyr/Kconfig"


### PR DESCRIPTION
## Add a hook for an externally supplied BLE/LC3 ROM API

### Summary
Add an opt-in mechanism for an out-of-tree module to supply the BLE/LC3 ROM
API — the public headers, the ROM symbol-address linker scripts, and the
host-stack patch — instead of the version bundled in this HAL.

### Motivation
The BLE/LC3 ROM API is currently fixed to the version bundled in this HAL. This
provides no way to build against a different ROM, which is required for **ROM
development**: a ROM build under development has its own symbol addresses and
host-stack patch, paired to the ROM image they were produced from, and is not
part of this HAL.

### Changes
| File | Change |
| --- | --- |
| `zephyr/Kconfig` | Add `ALIF_BLE_ROM_API_EXTERNAL` and the path options `ALIF_BLE_ROM_API_DIR`, `ALIF_LC3_ROM_API_DIR`, `ALIF_BLE_ROM_SYMBOLS_LDS`, `ALIF_LC3_ROM_SYMBOLS_LDS`. |
| `ble/CMakeLists.txt` | When `ALIF_BLE_ROM_API_EXTERNAL` is set, `add_subdirectory()` the external provider instead of the bundled `v1_2`; export `ALIF_BLE_ROM_PATCH_LD_DIR` so the provider reuses the HAL's patch-section scripts. |
| `lc3/CMakeLists.txt` | Same selection for the external LC3 provider. |
| `linker_add_rom_symbols.ld` | When `ALIF_BLE_ROM_API_EXTERNAL` is set, `#include` the external `ALIF_*_ROM_SYMBOLS_LDS` scripts in place of the bundled ones. |

### Contract for an external provider
The provider directory is added with `add_subdirectory()` and must expose the
public API headers, link the host-stack patch, and wire the patch sections (via
`ALIF_BLE_ROM_PATCH_LD_DIR`). `ALIF_BLE_ROM_SYMBOLS_LDS` / `ALIF_LC3_ROM_SYMBOLS_LDS`
are absolute paths to the ROM symbol-address linker scripts.

### Compatibility
Opt-in. When `ALIF_BLE_ROM_API_EXTERNAL` is not set, the bundled ROM API is used
as before. The on-chip ROM is not shipped or modified; only the interface used to
call into it is supplied.