### PR TITLE
drivers: ethos_u: build cache callbacks only on Cortex-M

### DIFF
--- a/drivers/ethos_u/CMakeLists.txt
+++ b/drivers/ethos_u/CMakeLists.txt
@@ -1,3 +1,10 @@
-zephyr_include_directories( include )
-zephyr_library()
-zephyr_library_sources(src/ethosu_callback.c)
+# The Alif Ethos-U cache-maintenance callbacks are Cortex-M specific: they use
+# CMSIS-M SCB_* cache intrinsics (cmsis_core.h) and TCM local->global address
+# remapping (soc_memory_map.h), neither of which exist on APSS (Cortex-A32).
+# On APSS the tensor arena lives in non-cacheable SRAM1, so the Ethos-U driver's
+# weak NOP cache ops and identity address remap are already correct.
+if(CONFIG_CPU_CORTEX_M)
+  zephyr_include_directories( include )
+  zephyr_library()
+  zephyr_library_sources(src/ethosu_callback.c)
+endif()


### PR DESCRIPTION
Problem

ethosu_callback.c uses Cortex-M–specific CMSIS cache intrinsics (SCB_CleanDCache, SCB_InvalidateDCache_by_Addr) and TCM address remapping (soc_memory_map.h). These do not exist on Cortex-A32 (APSS), causing a build failure when Ethos-U85 is used on APSS.

Fix

Guard the build with CONFIG_CPU_CORTEX_M. On APSS, the tensor arena is in non-cacheable SRAM1, so the Ethos-U driver's existing weak no-op defaults for cache ops and address remap are sufficient.

Testing

RTSS (Cortex-M55): no behavioural change.
APSS (Cortex-A32): tflm_ethosu sample builds and runs on alif_e8_dk/ae822fa0e5597xx0/apss with Ethos-U85-256.
Related: sdk-alif PR #761, zephyr_alif PR #517