### PR TITLE
drivers: analog: Update LDO and bandgap calibration values for ADC

### DIFF
--- a/drivers/analog/include/analog_ctrl.h
+++ b/drivers/analog/include/analog_ctrl.h
@@ -70,7 +70,7 @@ extern "C" {
  * 1111: 1.9 V
  * Step: 20 mV Default (0xA)
  */
-#define ANA_PERIPH_LDO_CONT		(0xAU << 6)
+#define ANA_PERIPH_LDO_CONT		(0x8U << 6)
 
 /* Calibration for analog peripherals precision bandgap:
  * 0000: 1.140 V
@@ -79,7 +79,7 @@ extern "C" {
  * 1111: 1.233 V
  * Step: 6 mV Default (0xA)
  */
-#define ANA_PERIPH_BG_CONT		(0xAU << 1)
+#define ANA_PERIPH_BG_CONT		(0x8U << 1)
 
 #define CMP_CTRL_CMP0_CLKEN	(1U << 0U) /* Enable CMP0 clock */
 
@@ -90,6 +90,8 @@ extern "C" {
 #define DAC12_REF_VAL		(DAC12_VREF_CONT | ADC_VREF_BUF_EN | ADC_VREF_BUF_RDIV_EN)
 
 #define ADC_REF_VAL			(ADC_VREF_BUF_RDIV_EN | ADC_VREF_BUF_EN | ADC_VREF_CONT)
+
+#define ANA_PERIPH_LDO_BG_CONT_VAL	(ANA_PERIPH_LDO_CONT | ANA_PERIPH_BG_CONT)
 
 extern uint32_t analog_ldo_ref_cnt;
 extern uint32_t adc_vref_cnt;
@@ -271,22 +273,27 @@ static inline void disable_dac12_ref_voltage_alias_mode(uintptr_t cmp_reg2, uint
  */
 static inline void enable_adc_ref_voltage(uintptr_t cmp_reg2)
 {
-	REG(cmp_reg2) |= ADC_REF_VAL;
+	REG(cmp_reg2) |= (ADC_REF_VAL | ANA_PERIPH_LDO_BG_CONT_VAL);
 	adc_vref_cnt++;
 }
 
 /**
- * @fn      void enable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base)
+ * @fn      void enable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base,
+ *             uintptr_t cmp_reg2)
  * @brief   Enable ADC reference voltage (aliasing mode).
  *          Configures the ADC VREF register to enable the
  *          reference divider, turn on the VREF buffer, and set the
  *          appropriate control level for the ADC reference voltage.
+ *          Applies the LDO output voltage and bandgap calibration
+ *          values on the comparator control register.
  * @param[in] adc_vref_base  Base address of the ADC VREF register.
+ * @param[in] cmp_reg2       Base address of the comparator control register.
  * @return   none
  */
-static inline void enable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base)
+static inline void enable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base, uintptr_t cmp_reg2)
 {
 	REG(adc_vref_base) |= ADC_REF_VAL;
+	REG(cmp_reg2) |= ANA_PERIPH_LDO_BG_CONT_VAL;
 	adc_vref_cnt++;
 }
 
@@ -301,22 +308,25 @@ static inline void disable_adc_ref_voltage(uintptr_t cmp_reg2)
 {
 	adc_vref_cnt--;
 	if (adc_vref_cnt == 0) {
-		REG(cmp_reg2) &= ~ADC_REF_VAL;
+		REG(cmp_reg2) &= ~(ADC_REF_VAL | ANA_PERIPH_LDO_BG_CONT_VAL);
 	}
 }
 
 /**
- * @fn        void disable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base)
+ * @fn        void disable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base,
+ *               uintptr_t cmp_reg2)
  * @brief     Disable the reference divider, VREF buffer,
  *            and ADC reference voltage (aliasing mode).
  * @param[in] adc_vref_base  Base address of the ADC VREF register.
+ * @param[in] cmp_reg2       Base address of the comparator control register.
  * @return     none
  */
-static inline void disable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base)
+static inline void disable_adc_ref_voltage_alias_mode(uintptr_t adc_vref_base, uintptr_t cmp_reg2)
 {
 	adc_vref_cnt--;
 	if (adc_vref_cnt == 0) {
 		REG(adc_vref_base) &= ~ADC_REF_VAL;
+		REG(cmp_reg2) &= ~ANA_PERIPH_LDO_BG_CONT_VAL;
 	}
 }
 


### PR DESCRIPTION
The default LDO output voltage (VDD_ANA) and bandgap calibration values are trimmed for improved ADC accuracy.

ANA_PERIPH_LDO_CONT: 0xA (1.80V) -> 0x8 (1.76V)
ANA_PERIPH_BG_CONT:  0xA (1.200V) -> 0x8 (1.188V)

Apply the trimmed LDO and bandgap calibration values whenever the ADC reference voltage is enabled. A new ANA_PERIPH_LDO_BG_CONT_VAL combines both fields and is written to the comparator control register in enable_adc_ref_voltage() and cleared in disable_adc_ref_voltage(). The aliasing-mode helpers now also take the comparator register base so the same calibration is applied in that path.

Adapted from: https://github.com/alifsemi/alif_ensemble-cmsis-dfp/commit/bd9b77d1fb00229476faa1e3b8111ab1537212ce