### PR TITLE
Introduce se_service_get_setting_api API to retrieve the runtime clocks

### DIFF
--- a/se_services/zephyr/include/se_service.h
+++ b/se_services/zephyr/include/se_service.h
@@ -306,6 +306,23 @@ int se_service_update_stoc(uint8_t *img_addr, uint32_t img_size);
 int se_service_clock_set_divider(clock_divider_t divider, uint32_t value);
 
 /**
+ * @brief Send service request to SE to get a clock frequency setting.
+ *
+ * Queries the actual clock frequency configured by SE firmware for the
+ * given setting. Use this instead of hardcoded values, since SE run
+ * profile changes affect these frequencies.
+ *
+ * @param setting Clock setting to query.
+ * @param freq Pointer to store frequency value in Hz.
+ * @retval 0 Success.
+ * @retval -EINVAL Invalid argument.
+ * @retval -EAGAIN Operation timed out. Retry after a delay.
+ * @retval -EBUSY SE is busy. Retry after a delay.
+ * @return Positive error code returned by SE for a failed service request.
+ */
+int se_service_clock_setting_get(clock_setting_t setting, uint32_t *freq);
+
+/**
  * @brief Send service request to SE to process TOC entry.
  *
  * @param image_id ID that matches the TOC entry field image identifier.

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -461,19 +461,27 @@ static int send_msg_to_se(uint32_t *ptr, uint32_t size, uint32_t timeout)
 		/* Disable Rx MHU interrupts */
 		ipm_set_enabled(recv_dev, false);
 
-		err = ipm_poll_out(send_dev, CH_ID, &global_address, (int)size, K_MSEC(timeout));
+		err = ipm_poll_out(send_dev, CH_ID, &global_address,
+				(int)size, K_MSEC(timeout));
 		if (err) {
-			LOG_ERR("failed to send service %d\n", service_id);
-			return err;
+			LOG_ERR("failed to send service %d (err=%d)",
+				service_id, err);
+			goto poll_cleanup;
 		}
 
-		err = ipm_poll_in(recv_dev, CH_ID, &rx_data, (int)size, K_MSEC(timeout));
+		err = ipm_poll_in(recv_dev, CH_ID, &rx_data,
+				(int)size, K_MSEC(timeout));
 		if (err) {
-			LOG_ERR("failed to rcv resp for service %d\n", service_id);
+			LOG_ERR("failed to rcv resp for service %d (err=%d)",
+				service_id, err);
+		}
+
+poll_cleanup:
+		ipm_set_enabled(recv_dev, true);
+
+		if (err) {
 			return err;
 		}
-		/* Enable Rx MHU interrupts */
-		ipm_set_enabled(recv_dev, true);
 	}
 
 	sys_cache_data_invd_range(ptr, size);

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -321,6 +321,7 @@ typedef union {
 	boot_cpu_svc_t boot_cpu_svc_d;
 	power_setting_svc_t power_setting_svc_d;
 	lp_cmp_configure_svc_t lp_cmp_configure_svc_d;
+	clock_setting_svc_t clock_setting_svc_d;
 } se_service_all_svc_t;
 
 /*
@@ -1648,6 +1649,53 @@ int se_service_clock_set_divider(clock_divider_t divider, uint32_t value)
 		LOG_ERR("received response error = %d\n", resp_err);
 		return resp_err;
 	}
+	return 0;
+}
+
+int se_service_clock_setting_get(clock_setting_t setting, uint32_t *freq)
+{
+	int err, resp_err = -1;
+
+	if (!freq) {
+		LOG_ERR("Invalid argument\n");
+		return -EINVAL;
+	}
+
+	err = se_service_ensure_ready();
+	if (err) {
+		return err;
+	}
+
+	err = k_mutex_lock(&svc_mutex, K_MSEC(MUTEX_TIMEOUT));
+	if (err) {
+		LOG_ERR("Unable to lock mutex (error = %d)\n", err);
+		return err;
+	}
+
+	memset(&se_service_all_svc_d, 0, sizeof(se_service_all_svc_d));
+	se_service_all_svc_d.clock_setting_svc_d.header.hdr_service_id =
+		SERVICE_CLOCK_SETTING_GET_REQ_ID;
+	se_service_all_svc_d.clock_setting_svc_d.send_setting_type = setting;
+
+	err = send_msg_to_se((uint32_t *)&se_service_all_svc_d.clock_setting_svc_d,
+			     sizeof(se_service_all_svc_d.clock_setting_svc_d),
+			     SERVICE_TIMEOUT);
+	resp_err = se_service_all_svc_d.clock_setting_svc_d.resp_error_code;
+
+	if (err) {
+		LOG_ERR("%s failed with %d\n", __func__, err);
+		k_mutex_unlock(&svc_mutex);
+		return err;
+	}
+	if (resp_err) {
+		LOG_ERR("%s: received response error = %d\n", __func__, resp_err);
+		k_mutex_unlock(&svc_mutex);
+		return resp_err;
+	}
+
+	*freq = se_service_all_svc_d.clock_setting_svc_d.value;
+	k_mutex_unlock(&svc_mutex);
+
 	return 0;
 }
 

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -6,6 +6,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 #include <zephyr/dt-bindings/misc/alif_aipm_common.h>
 #include <se_service.h>
 #include <soc_memory_map.h>
@@ -422,8 +423,13 @@ static int send_msg_to_se(uint32_t *ptr, uint32_t size, uint32_t timeout)
 	if (k_can_yield()) {
 		int wait = 0;
 
-		/* Prevent sleeps during SE service calls */
-		pm_device_busy_set(send_dev);
+		/*
+		 * Block SUSPEND_TO_RAM / SOFT_OFF while we hold svc_mutex and
+		 * wait on the SE mailbox response. Otherwise the idle thread
+		 * may run PM device-suspend callbacks
+		 */
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
 
 		k_sem_reset(&svc_send_sem);
 		k_sem_reset(&svc_recv_sem);
@@ -432,27 +438,27 @@ static int send_msg_to_se(uint32_t *ptr, uint32_t size, uint32_t timeout)
 		err = ipm_send(send_dev, wait, CH_ID, &global_address, (int)size);
 		if (err) {
 			LOG_ERR("failed to send request for MSG(error: %d)\n", err);
-			pm_device_busy_clear(send_dev);
-			return err;
+			goto unlock;
 		}
 
 		err = k_sem_take(&svc_send_sem, K_MSEC(timeout));
 		if (err) {
 			LOG_ERR("service %d send is timed out!\n", service_id);
-			pm_device_busy_clear(send_dev);
-			return err;
+			goto unlock;
 		}
-
-		pm_device_busy_set(recv_dev);
-		pm_device_busy_clear(send_dev);
 
 		err = k_sem_take(&svc_recv_sem, K_MSEC(timeout));
 		if (err) {
 			LOG_ERR("service %d response is timed out!\n", service_id);
-			pm_device_busy_clear(recv_dev);
+		}
+
+unlock:
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+
+		if (err) {
 			return err;
 		}
-		pm_device_busy_clear(recv_dev);
 
 	} else {
 		uint32_t rx_data = 0;


### PR DESCRIPTION
This pull request introduces a new API for querying clock frequency settings from the SE firmware. 
Use PM policy locks (pm_policy_state_lock_get/put) instead of device busy flags, preventing the system from entering suspend or soft-off states during SE service calls. Also, improved error handling to ensure locks are always released. 