### PR TITLE
drivers: utimer: add HAL helpers for shared clock/running checks

### DIFF
--- a/drivers/utimer/include/utimer.h
+++ b/drivers/utimer/include/utimer.h
@@ -581,4 +581,20 @@ void alif_utimer_enable_filter(uint32_t reg_base, uint8_t prescaler,
  */
 void alif_utimer_disable_filter(uint32_t reg_base);
 
+/**
+ * \fn        bool alif_utimer_all_channel_clocks_disabled(uint32_t reg_base)
+ * \brief     check whether all channel clocks are disabled.
+ * \param[in] reg_base  register base address
+ * \return    true if all channel clocks are disabled, otherwise false
+ */
+bool alif_utimer_all_channel_clocks_disabled(uint32_t reg_base);
+
+/**
+ * \fn        bool alif_utimer_any_counter_running(uint32_t reg_base)
+ * \brief     check whether any channel counter is running.
+ * \param[in] reg_base  register base address
+ * \return    true if any channel counter is running, otherwise false
+ */
+bool alif_utimer_any_counter_running(uint32_t reg_base);
+
 #endif /* UTIMER_H_ */

--- a/drivers/utimer/src/utimer.c
+++ b/drivers/utimer/src/utimer.c
@@ -307,3 +307,18 @@ void alif_utimer_disable_filter(uint32_t reg_base)
 	REG(UTIMER_FILTER_CTRL_A(reg_base)) &= ~CHAN_FILTER_CTRL_FILTER_EN;
 	REG(UTIMER_FILTER_CTRL_B(reg_base)) &= ~CHAN_FILTER_CTRL_FILTER_EN;
 }
+
+bool alif_utimer_all_channel_clocks_disabled(uint32_t reg_base)
+{
+	/* GLB_CLK_EN masks the valid channel bits [15:0]. Reading zero
+	 * means no channel on this UTIMER IP has its clock enabled,
+	 * i.e. no counter/pwm/qdec driver instance is currently using
+	 * any channel of the block.
+	 */
+	return ((REG(UTIMER_GLB_CLOCK_ENABLE(reg_base)) & GLB_CLK_EN) == 0U);
+}
+
+bool alif_utimer_any_counter_running(uint32_t reg_base)
+{
+	return ((REG(UTIMER_GLB_CNTR_RUNNING(reg_base)) & GLB_CNTR_RUNNING) != 0U);
+}


### PR DESCRIPTION


Added alif_utimer_any_counter_running() and alif_utimer_all_channel_clocks_disabled(),
reading GLB_CNTR_RUNNING and GLB_CLOCK_ENABLE respectively. 

These let the counter, pwm, and qdec drivers
which share one UTIMER register block, correctly
refuse suspend while any channel is active, and
gate the shared clock only once every channel has
released it with no driver aware of the others.