### PR TITLE
clang-format: sync with upstream Zephyr v4.4.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,17 +32,21 @@ ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 ForEachMacros:
+  - 'ARRAY_FOR_EACH'
+  - 'ARRAY_FOR_EACH_PTR'
   - 'FOR_EACH'
   - 'FOR_EACH_FIXED_ARG'
   - 'FOR_EACH_IDX'
   - 'FOR_EACH_IDX_FIXED_ARG'
   - 'FOR_EACH_NONEMPTY_TERM'
+  - 'FOR_EACH_FIXED_ARG_NONEMPTY_TERM'
   - 'RB_FOR_EACH'
   - 'RB_FOR_EACH_CONTAINER'
   - 'SYS_DLIST_FOR_EACH_CONTAINER'
   - 'SYS_DLIST_FOR_EACH_CONTAINER_SAFE'
   - 'SYS_DLIST_FOR_EACH_NODE'
   - 'SYS_DLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SEM_LOCK'
   - 'SYS_SFLIST_FOR_EACH_CONTAINER'
   - 'SYS_SFLIST_FOR_EACH_CONTAINER_SAFE'
   - 'SYS_SFLIST_FOR_EACH_NODE'
@@ -52,6 +56,7 @@ ForEachMacros:
   - 'SYS_SLIST_FOR_EACH_NODE'
   - 'SYS_SLIST_FOR_EACH_NODE_SAFE'
   - '_WAIT_Q_FOR_EACH'
+  - '_WAIT_Q_FOR_EACH_SAFE'
   - 'Z_FOR_EACH'
   - 'Z_FOR_EACH_ENGINE'
   - 'Z_FOR_EACH_EXEC'
@@ -66,8 +71,21 @@ ForEachMacros:
   - 'Z_GENLIST_FOR_EACH_NODE'
   - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
   - 'STRUCT_SECTION_FOREACH'
+  - 'STRUCT_SECTION_FOREACH_ALTERNATE'
   - 'TYPE_SECTION_FOREACH'
   - 'K_SPINLOCK'
+  - 'COAP_RESOURCE_FOREACH'
+  - 'COAP_SERVICE_FOREACH'
+  - 'COAP_SERVICE_FOREACH_RESOURCE'
+  - 'HTTP_RESOURCE_FOREACH'
+  - 'HTTP_SERVER_CONTENT_TYPE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH_RESOURCE'
+  - 'I3C_BUS_FOR_EACH_I3CDEV'
+  - 'I3C_BUS_FOR_EACH_I3CDEV_SAFE'
+  - 'I3C_BUS_FOR_EACH_I2CDEV'
+  - 'I3C_BUS_FOR_EACH_I2CDEV_SAFE'
+  - 'MIN_HEAP_FOREACH'
 IfMacros:
   - 'CHECKIF'
 # Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520
@@ -82,11 +100,20 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IndentCaseLabels: false
+IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
+InsertNewlineAtEOF: true
+SpaceBeforeInheritanceColon: False
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never
 UseTab: ForContinuationAndIndentation
 WhitespaceSensitiveMacros:
+  - COND_CODE_0
+  - COND_CODE_1
+  - IF_DISABLED
+  - IF_ENABLED
+  - LISTIFY
   - STRINGIFY
   - Z_STRINGIFY
+  - DT_FOREACH_PROP_ELEM_SEP


### PR DESCRIPTION
Update .clang-format to match the version from the Zephyr v4.4.0 release.