### PR TITLE
APSS SE interfacing improvements

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,6 +7,10 @@ if(CONFIG_RTSS_HE OR CONFIG_RTSS_HP)
   zephyr_library_sources(src/system.c)
 endif()
 
+if(CONFIG_APSS)
+  zephyr_include_directories(include)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_HAS_ALIF_POWER_MANAGER
     src/es0_power_manager.c
 )

--- a/common/include/soc_memory_map.h
+++ b/common/include/soc_memory_map.h
@@ -12,6 +12,8 @@ extern "C" {
 
 #include <zephyr/devicetree.h>
 
+#if DT_NODE_EXISTS(DT_NODELABEL(itcm)) && DT_NODE_EXISTS(DT_NODELABEL(dtcm))
+
 #define ITCM_BASE (DT_REG_ADDR(DT_NODELABEL(itcm)))
 #define ITCM_SIZE (DT_REG_SIZE(DT_NODELABEL(itcm)))
 #define DTCM_BASE (DT_REG_ADDR(DT_NODELABEL(dtcm)))
@@ -31,6 +33,15 @@ static inline uint32_t local_to_global(const volatile void *local_addr)
 		return (addr);
 	}
 }
+
+#else /* No local TCM remap (e.g. Cortex-A32/APSS): addresses are already global */
+
+static inline uint32_t local_to_global(const volatile void *local_addr)
+{
+	return (uint32_t)local_addr;
+}
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/se_services/zephyr/src/se_service.c
+++ b/se_services/zephyr/src/se_service.c
@@ -320,7 +320,26 @@ typedef union {
 	boot_cpu_svc_t boot_cpu_svc_d;
 } se_service_all_svc_t;
 
-static se_service_all_svc_t se_service_all_svc_d;
+/*
+ * The SE communication buffer is shared with the Secure Enclave over MHUv2 and
+ * kept coherent with explicit cache maintenance (flush before send, invalidate
+ * after receive). It must therefore occupy whole cache lines of its own: if a
+ * neighbouring variable shares a boundary cache line, that line can be written
+ * back over the SE response, corrupting it (seen as all-zero data when e.g.
+ * CONFIG_THREAD_MONITOR changes the .bss layout).
+ */
+#if defined(CONFIG_DCACHE_LINE_SIZE) && (CONFIG_DCACHE_LINE_SIZE > 0)
+#define SE_SVC_BUF_ALIGN CONFIG_DCACHE_LINE_SIZE
+#else
+#define SE_SVC_BUF_ALIGN sizeof(uint32_t)
+#endif
+
+static union {
+	se_service_all_svc_t svc;
+	uint8_t pad[ROUND_UP(sizeof(se_service_all_svc_t), SE_SVC_BUF_ALIGN)];
+} se_service_all_svc_buf __aligned(SE_SVC_BUF_ALIGN);
+#define se_service_all_svc_d (se_service_all_svc_buf.svc)
+
 static uint32_t global_address;
 static uint32_t se_service_recv_data;
 


### PR DESCRIPTION
This pull request introduces improvements for better platform support and memory safety, particularly targeting APSS and Secure Enclave communication. The main changes include conditional inclusion of directories for APSS, safer memory mapping for platforms without TCM, and improved alignment for the Secure Enclave communication buffer to prevent cache-related data corruption.

**Platform support and configuration:**
* Added conditional inclusion of the `include` directory in `common/CMakeLists.txt` when `CONFIG_APSS` is set, improving build configuration for APSS platforms.

**Memory mapping enhancements:**
* Wrapped ITCM/DTCM memory mapping macros in `soc_memory_map.h` with a check for device tree nodes, ensuring these definitions only exist when both ITCM and DTCM are present.
* Provided a fallback implementation of `local_to_global()` for platforms without local TCM remap (such as Cortex-A32/APSS), which simply returns the address as-is.

**Memory alignment and cache safety:**
* Replaced the static `se_service_all_svc_d` variable with a union that is explicitly aligned to the data cache line size (or 32-bit word if undefined) in `se_service.c`. This ensures that the Secure Enclave communication buffer does not share cache lines with other variables, preventing corruption due to cache line sharing.