### PR TITLE
drivers: analog: include: add missing bandgap field mask

### DIFF
--- a/drivers/analog/include/analog_ctrl.h
+++ b/drivers/analog/include/analog_ctrl.h
@@ -83,6 +83,7 @@ extern "C" {
  * Step: 6 mV Default (0x8)
  */
 #define ANA_PERIPH_BG_CONT		(0x8U << 1)
+#define ANA_PERIPH_BG_MASK		(0xFU << 1)
 
 #define ANA_PERIPH_LDO_BG_MASK		(ANA_PERIPH_LDO_MASK | ANA_PERIPH_BG_MASK)
 #define ANA_PERIPH_LDO_BG_CONT_VAL	(ANA_PERIPH_LDO_CONT | ANA_PERIPH_BG_CONT)


### PR DESCRIPTION
ANA_PERIPH_LDO_BG_MASK already uses ANA_PERIPH_BG_MASK, but that symbol was never defined. Add a 4-bit mask at bits [4:1] to match ANA_PERIPH_BG_CONT.